### PR TITLE
Longueur max 30 char sur les titres. À changer en fonction du redesign.

### DIFF
--- a/app/views/shared/_card.html.erb
+++ b/app/views/shared/_card.html.erb
@@ -8,7 +8,7 @@
     </span>
 
     <div class="card-body slide-up">
-      <h4 class="card-title font-weight-bold text-primary"><%= project.name %></h4>
+      <h4 class="card-title font-weight-bold text-primary"><%= truncate(project.name, length: 30) %></h4>
       <h5 class="card-text font-weight-bold text-info text-bold"><%= project.city %></h5>
       <div class="above-bar-info d-flex justify-content-between">
         <div class="text-left">


### PR DESCRIPTION
À voir pour changer le nombre de caractères suivant la nouvelle taille du titre, mais ça évite que le titre de la carte s'étale sur plus de deux lignes.

Fix #58 

@pataus91 à merger/utileser avec le redesign de la carte que tu fais.